### PR TITLE
Suggestion to soft-pin dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ package_dir=
 packages = find:
 install_requires =
     django=={{ django_version }}
-    envparse==0.2.0
+    envparse>=0.2,<0.3
 python_requires = >=3.5
 
 [options.entry_points]
@@ -52,7 +52,7 @@ console_scripts =
 [options.extras_require]
 dev =
     check-manifest==0.37
-    django-debug-toolbar==1.10.1
+    django-debug-toolbar>=1.10,<1.11
     ipython==7.1.1
 
 [options.packages.find]


### PR DESCRIPTION
In order to not have to carefully maintain this template for each and every upstream change, I would suggest to not specify patch versions of dependencies?

For me personally, this would not cause any alarm.. on the contrary, I often use soft version pinning to avoid missing out on security upgrades.